### PR TITLE
fix: handle error payload, improve exit handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@ async fn handle_read(amount: usize, state: &mut ProtocolState) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn protocol_task(
     mut child: Child,
     stdout: ChildStdout,
@@ -1152,25 +1153,25 @@ impl EsbuildFlags {
                 flags.push(format!("--external:{}", external));
             }
         }
-        if let Some(minify) = self.minify {
-            if minify {
-                flags.push("--minify".to_string());
-            }
+        if let Some(minify) = self.minify
+            && minify
+        {
+            flags.push("--minify".to_string());
         }
-        if let Some(splitting) = self.splitting {
-            if splitting {
-                flags.push("--splitting".to_string());
-            }
+        if let Some(splitting) = self.splitting
+            && splitting
+        {
+            flags.push("--splitting".to_string());
         }
         if let Some(defines) = &self.defines {
             for (key, value) in defines {
                 flags.push(format!("--define:{}={}", key, value));
             }
         }
-        if let Some(metafile) = self.metafile {
-            if metafile {
-                flags.push("--metafile".to_string());
-            }
+        if let Some(metafile) = self.metafile
+            && metafile
+        {
+            flags.push("--metafile".to_string());
         }
         if let Some(sourcemap) = self.sourcemap {
             flags.push(format!("--sourcemap={}", sourcemap));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,10 @@ impl EsbuildService {
         &self.client
     }
 
+    pub async fn stop(self) -> Result<(), AnyError> {
+        self.client.send_stop().await
+    }
+
     pub async fn wait_for_exit(&self) -> Result<ExitStatus, AnyError> {
         if self.exited.borrow().is_some() {
             return Ok(self.exited.borrow().unwrap());
@@ -832,7 +836,7 @@ impl ProtocolClientInner {
         }
     }
 
-    pub async fn stop(&self) -> Result<(), AnyError> {
+    async fn send_stop(&self) -> Result<(), AnyError> {
         self.stop_tx.send(()).await?;
         Ok(())
     }

--- a/src/protocol/encode.rs
+++ b/src/protocol/encode.rs
@@ -253,6 +253,7 @@ impl Encode for AnyResponse {
             AnyResponse::Resolve(resolve_response) => todo!(),
             AnyResponse::OnResolve(on_resolve_response) => on_resolve_response.encode_into(buf),
             AnyResponse::OnLoad(on_load_response) => on_load_response.encode_into(buf),
+            AnyResponse::Ping(ping_response) => ping_response.encode_into(buf),
         }
     }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -27,7 +27,8 @@ async fn test_basic_build() -> Result<(), Box<dyn std::error::Error>> {
             flags,
             ..Default::default()
         })
-        .await?;
+        .await?
+        .unwrap();
 
     // Check that build succeeded
     assert!(

--- a/tests/build_with_errors.rs
+++ b/tests/build_with_errors.rs
@@ -25,7 +25,8 @@ async fn test_build_with_errors() -> Result<(), Box<dyn std::error::Error>> {
             flags,
             ..Default::default()
         })
-        .await?;
+        .await?
+        .unwrap();
 
     // Check that build failed with errors
     assert!(

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -76,11 +76,12 @@ async fn context_simple() -> Result<(), Box<dyn std::error::Error>> {
             }]),
             ..Default::default()
         })
-        .await?;
+        .await?
+        .unwrap();
 
     assert!(response.errors.is_empty());
 
-    let response = esbuild.client().send_rebuild_request(1).await?;
+    let response = esbuild.client().send_rebuild_request(1).await?.unwrap();
     assert!(response.errors.is_empty());
     assert!(response.warnings.is_empty());
 

--- a/tests/define.rs
+++ b/tests/define.rs
@@ -30,7 +30,8 @@ async fn test_basic_build() -> Result<(), Box<dyn std::error::Error>> {
             flags,
             ..Default::default()
         })
-        .await?;
+        .await?
+        .unwrap();
 
     // Check that build succeeded
     assert!(

--- a/tests/metafile.rs
+++ b/tests/metafile.rs
@@ -31,7 +31,8 @@ async fn test_basic_build() -> Result<(), Box<dyn std::error::Error>> {
             flags,
             ..Default::default()
         })
-        .await?;
+        .await?
+        .unwrap();
 
     // Check that build succeeded
     assert!(

--- a/tests/plugin_hook.rs
+++ b/tests/plugin_hook.rs
@@ -163,7 +163,8 @@ console.log('PI =', PI);
             plugins: Some(vec![plugin]),
             ..Default::default()
         })
-        .await?;
+        .await?
+        .unwrap();
 
     // Check that build succeeded
     assert!(


### PR DESCRIPTION
- Handles the fact that certain requests can fail and return an `error` payload instead of the response w/ errors in it.
- Enable ping handling to prevent deadlock on exit
- enable kill on drop to prevent zombies